### PR TITLE
chore: prefer canonical capability ids in runtime references

### DIFF
--- a/demos/decision-agent/sample_output.md
+++ b/demos/decision-agent/sample_output.md
@@ -72,9 +72,9 @@ Pasos ejecutados:
 
 1. merge_context - text.content.merge
 2. generate_options - agent.option.generate
-3. analyze_options - eval.option.analyze
-4. evaluate_options - eval.option.score
+3. analyze_options - reasoning.option.analyze
+4. evaluate_options - evaluation.option.score
 5. justify_decision - decision.option.justify
-6. assess_quality - eval.output.score
+6. assess_quality - evaluation.output.score
 
 La ejecucion fue completa y saludable, sin fallback.

--- a/docs/BINDING_SELECTION.md
+++ b/docs/BINDING_SELECTION.md
@@ -109,7 +109,7 @@ implementation:
 | `text.content.generate` | Echoes the instruction |
 | `text.content.classify` | Returns first candidate category |
 | `text.content.embed` | Hash-based pseudo-embedding |
-| `text.entity.extract` | Regex-based extraction (type = OTHER) |
+| `perception.entity.extract` | Regex-based extraction (type = OTHER) |
 | `text.language.detect` | Defaults to `en` |
 | `text.content.transform` | Wraps text with the goal directive |
 | `text.response.extract` | Returns first sentence of context |
@@ -130,11 +130,11 @@ The `model.*` domain has two kinds of capabilities:
 | Capability | Baseline behaviour |
 |---|---|
 | `model.output.generate` | Mock / OpenAI only (no pythoncall baseline) |
-| `model.response.validate` | Structural check: empty fields, non-dict detection |
+| `evaluation.response.validate` | Structural check: empty fields, non-dict detection |
 | `model.embedding.generate` | Hash-based pseudo-embedding (128-dim default) |
 | `model.output.classify` | Keyword frequency + field-name heuristics |
-| `model.output.score` | Word overlap, sentence length, length ratio proxies |
-| `model.risk.score` | Pattern matching for toxicity, bias, injection markers |
+| `evaluation.output.score` | Word overlap, sentence length, length ratio proxies |
+| `evaluation.risk.score` | Pattern matching for toxicity, bias, injection markers |
 
 These baselines ensure the system never crashes — but for production use with
 LLM-dependent capabilities, **setting `OPENAI_API_KEY` is strongly

--- a/docs/COALA_MAPPING.md
+++ b/docs/COALA_MAPPING.md
@@ -53,9 +53,9 @@ Each capability declares `cognitive_hints.role` that maps to a CoALA processing 
 
 | `cognitive_hints.role` | CoALA Stage | Description | Example Capabilities |
 |-----------------------|-------------|-------------|---------------------|
-| `perceive` | Perception | Convert raw input to structured form | `text.entity.extract`, `audio.speech.transcribe` |
+| `perceive` | Perception | Convert raw input to structured form | `perception.entity.extract`, `audio.speech.transcribe` |
 | `analyze` | Internal reasoning | Examine and decompose | `code.source.analyze`, `analysis.problem.split` |
-| `evaluate` | Decision making | Score, rank, or judge | `eval.option.score`, `data.schema.validate` |
+| `evaluate` | Decision making | Score, rank, or judge | `evaluation.option.score`, `data.schema.validate` |
 | `synthesize` | Internal action | Combine information into new form | `text.content.summarize`, `text.content.merge` |
 | `act` | External action | Produce side effects | `fs.file.write`, `email.message.send` |
 | `retrieve` | Memory retrieval | Access stored knowledge | `memory.context.retrieve`, `research.source.retrieve` |

--- a/docs/STEP_CONTROL_FLOW.md
+++ b/docs/STEP_CONTROL_FLOW.md
@@ -208,7 +208,7 @@ steps:
 # Score each option with retry per iteration
 steps:
   - id: score_options
-    uses: eval.option.score
+    uses: evaluation.option.score
     input:
       option: "item"
       criteria: "vars.criteria"

--- a/experiments/generate_outputs.py
+++ b/experiments/generate_outputs.py
@@ -146,7 +146,7 @@ def generate_report(results, variability, orca_available, timestamp):
         "- ORCA Skill: `experiment.text-processing-pipeline` using capabilities"
     )
     lines.append(
-        "  `text.entity.extract` -> `text.content.summarize` -> `text.content.classify`."
+        "  `perception.entity.extract` -> `text.content.summarize` -> `text.content.classify`."
     )
     lines.append("")
     lines.append("### 1.3 Metrics")

--- a/experiments/registry/skills/experiment/experiment/text-processing-pipeline/skill.yaml
+++ b/experiments/registry/skills/experiment/experiment/text-processing-pipeline/skill.yaml
@@ -30,7 +30,7 @@ outputs:
 
 steps:
   - id: extract_entities
-    uses: text.entity.extract
+    uses: perception.entity.extract
     input:
       text: inputs.text
     output:

--- a/experiments/run_benchmark.py
+++ b/experiments/run_benchmark.py
@@ -686,7 +686,7 @@ def generate_report(
         "- ORCA Skill: `experiment.text-processing-pipeline` using capabilities"
     )
     lines.append(
-        "  `text.entity.extract` -> `text.content.summarize` -> `text.content.classify`."
+        "  `perception.entity.extract` -> `text.content.summarize` -> `text.content.classify`."
     )
     lines.append("")
     lines.append("### 1.3 Metrics")

--- a/experiments/skills/experiment.text-processing-pipeline/skill.yaml
+++ b/experiments/skills/experiment.text-processing-pipeline/skill.yaml
@@ -30,7 +30,7 @@ outputs:
 
 steps:
   - id: extract_entities
-    uses: text.entity.extract
+    uses: perception.entity.extract
     input:
       text: inputs.text
     output:

--- a/official_services/scaffold_service.py
+++ b/official_services/scaffold_service.py
@@ -773,11 +773,11 @@ def _select_executable_template_caps(
         "text.content.translate",
         "text.content.summarize",
         "text.content.classify",
-        "text.entity.extract",
-        "text.keyword.extract",
+        "perception.entity.extract",
+        "perception.keyword.extract",
         "text.language.detect",
         "text.content.embed",
-        "text.content.extract",
+        "perception.content.extract",
     }
     if goal_capability_ids:
         for goal_id in goal_capability_ids:

--- a/official_services/scaffold_service.py
+++ b/official_services/scaffold_service.py
@@ -347,11 +347,11 @@ def _rank_capabilities(
 def _infer_goal_capability_ids(intent: str) -> list[str]:
     txt = intent.lower()
     ordered_matches: list[tuple[tuple[str, ...], str]] = [
-        (("extract", "entity"), "text.entity.extract"),
-        (("extract", "entities"), "text.entity.extract"),
-        (("named", "entity"), "text.entity.extract"),
-        (("keyword",), "text.keyword.extract"),
-        (("keywords",), "text.keyword.extract"),
+        (("extract", "entity"), "perception.entity.extract"),
+        (("extract", "entities"), "perception.entity.extract"),
+        (("named", "entity"), "perception.entity.extract"),
+        (("keyword",), "perception.keyword.extract"),
+        (("keywords",), "perception.keyword.extract"),
         (("translate",), "text.content.translate"),
         (("translation",), "text.content.translate"),
         (("summarize",), "text.content.summarize"),
@@ -364,7 +364,7 @@ def _infer_goal_capability_ids(intent: str) -> list[str]:
         (("categorize",), "text.content.classify"),
         (("embed",), "text.content.embed"),
         (("embedding",), "text.content.embed"),
-        (("extract", "text"), "text.content.extract"),
+        (("extract", "text"), "perception.content.extract"),
     ]
 
     goal_ids: list[str] = []

--- a/runtime/test_cognitive_hints.py
+++ b/runtime/test_cognitive_hints.py
@@ -403,8 +403,8 @@ def test_consumes_chain_multi_step():
                 },
             },
         ),
-        "eval.option.score": _make_cap(
-            "eval.option.score",
+        "evaluation.option.score": _make_cap(
+            "evaluation.option.score",
             cognitive_hints={
                 "role": ["evaluate"],
                 "consumes": ["Risk", "Evidence"],
@@ -417,7 +417,7 @@ def test_consumes_chain_multi_step():
     steps = (
         _make_step("fetch", "web.page.fetch"),
         _make_step("extract", "analysis.risk.extract"),
-        _make_step("score", "eval.option.score"),
+        _make_step("score", "evaluation.option.score"),
     )
 
     warnings = validate_consumes_chain(steps, loader)

--- a/sdk/embedded.py
+++ b/sdk/embedded.py
@@ -300,8 +300,8 @@ def _classify_fallback_severity(
 
     ratio = fallback_steps_count / max(steps_count, 1)
     critical_uses = {
-        "eval.option.analyze",
-        "eval.option.score",
+        "reasoning.option.analyze",
+        "evaluation.option.score",
         "decision.option.justify",
     }
     critical_fallback = any(
@@ -310,7 +310,7 @@ def _classify_fallback_severity(
         if isinstance(step, dict)
     )
     scoring_completed = any(
-        step.get("uses") == "eval.option.score" and step.get("status") == "completed"
+        step.get("uses") == "evaluation.option.score" and step.get("status") == "completed"
         for step in step_diagnostics
         if isinstance(step, dict)
     )

--- a/sdk/embedded.py
+++ b/sdk/embedded.py
@@ -310,7 +310,8 @@ def _classify_fallback_severity(
         if isinstance(step, dict)
     )
     scoring_completed = any(
-        step.get("uses") == "evaluation.option.score" and step.get("status") == "completed"
+        step.get("uses") == "evaluation.option.score"
+        and step.get("status") == "completed"
         for step in step_diagnostics
         if isinstance(step, dict)
     )

--- a/test_capabilities_batch.py
+++ b/test_capabilities_batch.py
@@ -176,11 +176,11 @@ TEST_DATA = {
             {"text": "Unrelated source"},
         ],
     },
-    "eval.output.score": {
+    "evaluation.output.score": {
         "output": {"summary": "Short summary", "confidence": 0.9},
         "rubric": {"dimensions": {"completeness": 0.5, "clarity": 0.5}},
     },
-    "eval.option.analyze": {
+    "reasoning.option.analyze": {
         "options": [
             {
                 "id": "opt-a",
@@ -191,7 +191,7 @@ TEST_DATA = {
         ],
         "goal": "Choose deployment strategy for new service",
     },
-    "eval.option.score": {
+    "evaluation.option.score": {
         "options": [
             {
                 "id": "opt-a",
@@ -222,11 +222,11 @@ TEST_DATA = {
         "instruction": "Write a one-sentence description of Python.",
         "context": "Python is a programming language.",
     },
-    "text.entity.extract": {"text": "John Smith works at Google in Mountain View."},
-    "text.content.extract": {
+    "perception.entity.extract": {"text": "John Smith works at Google in Mountain View."},
+    "perception.content.extract": {
         "text": "<html><body><h1>Title</h1><p>This is a test paragraph with important information.</p></body></html>"
     },
-    "text.keyword.extract": {
+    "perception.keyword.extract": {
         "text": "Python is a great programming language for machine learning and data science applications."
     },
     "text.language.detect": {"text": "This is English text."},
@@ -289,18 +289,25 @@ TEST_DATA = {
         "output": {"text": "Contact admin at admin@corp.com, password=s3cret!"},
         "policy": {"remove_pii": True, "remove_harmful": True},
     },
-    "model.output.score": {
+    "evaluation.output.score": {
         "output": "The product launch was successful with strong user adoption.",
-        "instruction": "Evaluate the product launch summary.",
+        "rubric": {
+            "dimensions": [
+                {"name": "coverage", "description": "Covers the main outcome"},
+                {"name": "clarity", "description": "Is concise and readable"},
+            ]
+        },
+        "context": "Evaluate the product launch summary.",
     },
     "model.prompt.template": {
         "template": "Hello ${name}, your project ${project} is ready.",
         "variables": {"name": "Alice", "project": "Alpha"},
     },
-    "model.response.validate": {
+    "evaluation.response.validate": {
         "output": {"summary": "Q3 results were positive.", "confidence": 0.85},
+        "validation_policy": {"coherence": True, "grounding": False, "coverage": True},
     },
-    "model.risk.score": {
+    "evaluation.risk.score": {
         "output": "The system performed within normal parameters.",
     },
     # ── remaining gaps ──

--- a/test_capabilities_batch.py
+++ b/test_capabilities_batch.py
@@ -176,10 +176,6 @@ TEST_DATA = {
             {"text": "Unrelated source"},
         ],
     },
-    "evaluation.output.score": {
-        "output": {"summary": "Short summary", "confidence": 0.9},
-        "rubric": {"dimensions": {"completeness": 0.5, "clarity": 0.5}},
-    },
     "reasoning.option.analyze": {
         "options": [
             {

--- a/test_capabilities_batch.py
+++ b/test_capabilities_batch.py
@@ -218,7 +218,9 @@ TEST_DATA = {
         "instruction": "Write a one-sentence description of Python.",
         "context": "Python is a programming language.",
     },
-    "perception.entity.extract": {"text": "John Smith works at Google in Mountain View."},
+    "perception.entity.extract": {
+        "text": "John Smith works at Google in Mountain View."
+    },
     "perception.content.extract": {
         "text": "<html><body><h1>Title</h1><p>This is a test paragraph with important information.</p></body></html>"
     },

--- a/test_decision_make_skill.py
+++ b/test_decision_make_skill.py
@@ -97,7 +97,7 @@ def test_decision_make_with_preprovided_options(engine):
 def test_decision_make_with_risk_tolerance(engine):
     """
     Verify decision.make respects risk_tolerance setting.
-    Expects: risk_tolerance propagated through eval.option.score and affects scoring.
+    Expects: risk_tolerance propagated through evaluation.option.score and affects scoring.
     """
     request = ExecutionRequest(
         skill_id="decision.make",

--- a/test_openapi_runtime_guardrails.py
+++ b/test_openapi_runtime_guardrails.py
@@ -55,7 +55,7 @@ def test_critical_binding_short_timeout_is_high_risk():
 
 def test_retry_one_is_allowed():
     entry = _evaluate_binding(
-        _binding("text.keyword.extract", timeout_seconds=30, retry_count=1),
+        _binding("perception.keyword.extract", timeout_seconds=30, retry_count=1),
         _service(),
     )
 
@@ -65,7 +65,7 @@ def test_retry_one_is_allowed():
 
 def test_retry_above_one_is_flagged():
     entry = _evaluate_binding(
-        _binding("text.keyword.extract", timeout_seconds=30, retry_count=2),
+        _binding("perception.keyword.extract", timeout_seconds=30, retry_count=2),
         _service(),
     )
 
@@ -75,7 +75,7 @@ def test_retry_above_one_is_flagged():
 
 def test_missing_timeout_is_high_risk():
     entry = _evaluate_binding(
-        _binding("eval.output.score", timeout_seconds=None, retry_count=0),
+        _binding("evaluation.output.score", timeout_seconds=None, retry_count=0),
         _service(),
     )
 

--- a/test_skill_authoring.py
+++ b/test_skill_authoring.py
@@ -69,7 +69,7 @@ _TWO_STEP_SKILL = {
     "steps": [
         {
             "id": "extract",
-            "uses": "text.content.extract",
+            "uses": "perception.content.extract",
             "input": {"text": "inputs.document"},
             "output": {"extracted": "vars.extracted_text"},
         },

--- a/tooling/generate_mcp_bindings.py
+++ b/tooling/generate_mcp_bindings.py
@@ -28,7 +28,7 @@ PHASE_1_CAPABILITIES = [
     "text.content.generate",
     "text.content.rewrite",
     "text.content.classify",
-    "text.content.extract",
+    "perception.content.extract",
     "text.sentiment.analyze",
     "text.language.detect",
     "text.language.translate",
@@ -46,9 +46,9 @@ PHASE_1_CAPABILITIES = [
     "analysis.problem.split",
     "analysis.risk.extract",
     "analysis.theme.cluster",
-    "eval.option.score",
-    "eval.option.analyze",
-    "eval.output.score",
+    "evaluation.option.score",
+    "reasoning.option.analyze",
+    "evaluation.output.score",
 ]
 
 


### PR DESCRIPTION
## Summary
- switch runtime-facing references from legacy capability ids to canonical ids where official canonical bindings already exist
- update batch and skill-authoring tests to exercise canonical ids directly
- keep the previous CI repair on master separate from this follow-up cleanup

## Validation
- python -m pytest test_capabilities_batch.py test_skill_authoring.py -q -o " addopts=\